### PR TITLE
Fix build with GCC 7

### DIFF
--- a/libupnpp/control/service.hxx
+++ b/libupnpp/control/service.hxx
@@ -22,6 +22,7 @@
 #include <sys/types.h>
 #include <upnp/upnp.h>                  // for UPNP_E_BAD_RESPONSE, etc
 
+#include <functional>
 #include <iostream>                     // for basic_ostream, operator<<, etc
 #include <string>                       // for string, operator<<, etc
 

--- a/libupnpp/device/device.hxx
+++ b/libupnpp/device/device.hxx
@@ -22,6 +22,7 @@
 #include <pthread.h>
 #include <upnp/upnp.h>
 
+#include <functional>
 #include <unordered_map>
 #include <memory>
 #include <string>


### PR DESCRIPTION
Building libupnpp with GCC 7 throws the following error:

```
./libupnpp/control/service.hxx:65:6: error: 'function' in namespace 'std' does not name a template type
 std::function<void (const std::unordered_map<std::string, std::string>&)>
```

Fix this by including `functional` as suggested in https://github.com/medoc92/libupnpp/issues/18#issuecomment-306092572.

Fixes: #18